### PR TITLE
Access Shafts Reworked

### DIFF
--- a/src/script/events.lua
+++ b/src/script/events.lua
@@ -173,7 +173,20 @@ function events.on_canceled_deconstruction(_event)
 end
 
 function events.on_player_driving_changed_state(_event)
+	local _player = game.players[_event.player_index]
 	
+	if _player.vehicle ~= nil then
+		if pairdata.exists(_player.vehicle) then
+			local _pairdata = pairdata.get(_player.vehicle)
+			
+			if _pairdata.class == pairclass.get("access-shaft") then
+				local _paired_access_shaft = pairutil.find_paired_entity(_player.vehicle)
+				if api.valid(_paired_access_shaft) then
+					global.players_using_access_shafts[_player.name] = {time_waiting = 0, entity = _player, destination = _paired_access_shaft}
+				end
+			end
+		end
+	end
 end
 
 function events.on_put_item(_event)
@@ -232,7 +245,7 @@ end
 function eventmgr.update_players_using_access_shafts(_event)
 	global.players_using_access_shafts = global.players_using_access_shafts or {}
 	for k, v in pairs(global.players_using_access_shafts) do
-		if v.entity.walking_state.walking == true or v.destination == nil then
+		if v.entity.walking_state.walking == true or v.entity.vehicle == nil or v.destination == nil then
 			global.players_using_access_shafts[k] = nil
 		else
 			if v.time_waiting >= config.teleportation_time_waiting then
@@ -246,9 +259,11 @@ function eventmgr.update_players_using_access_shafts(_event)
 	end
 end
 
--- This function checks whether any players are near an access shaft and adds them to the global table for players using access shafts if they are within range of one and not moving
+--[[ This function checks whether any players are near an access shaft and adds them to the global table for players using access shafts if they are within range of one and not moving
+
+DEPRECATED - Access shafts are now vehicles, handled by on_player_driving_changed_state event. ]]--
 function eventmgr.check_player_collision_with_access_shafts(_event)
-	for _, _player in pairs(api.game.players()) do
+	--[[for _, _player in pairs(api.game.players()) do
 		if _player.walking_state.walking ~= true and global.players_using_access_shafts[_player.name] == nil then
 			local _access_shaft = surfaces.find_nearby_access_shaft(_player, config.teleportation_check_range, _player.surface)
 			if api.valid(_access_shaft) then
@@ -258,7 +273,7 @@ function eventmgr.check_player_collision_with_access_shafts(_event)
 				end
 			end
 		end
-	end
+	end]]--
 end
 
 -- This function updates the contents of each transport and receiver chest in the map, providing that they are both valid and if they are not, they will be destroyed

--- a/src/script/lib/pair-util.lua
+++ b/src/script/lib/pair-util.lua
@@ -160,6 +160,12 @@ function pairutil.destroy_paired_entity(_entity)
 	local _paired_entity = pairutil.find_paired_entity(_entity)
 	local _pair_data = pairdata.get(_entity) or pairdata.reverse(_entity)
 	table.insert(global.task_queue, struct.TaskSpecification(const.eventmgr.task.remove_sky_tile, {_entity, _paired_entity, _pair_data.radius}))
+	
+	if _pair_data.class == pairclass.get("access-shaft") then
+		_entity.get_inventory(defines.inventory.fuel).clear()
+		_paired_entity.get_inventory(defines.inventory.fuel).clear()
+	end
+	
 	api.destroy(_paired_entity)
 end
 

--- a/src/script/lib/pair-util.lua
+++ b/src/script/lib/pair-util.lua
@@ -136,6 +136,14 @@ function pairutil.finalize_paired_entity(_entity, _paired_entity, _player_index)
 				table.insert(global.item_transport, {input = _entity, output = _paired_entity, tier = _pair_data.custom.tier, modifier = _pair_data.modifier})
 			elseif _pair_data.class == pairclass.get("rail-transport") then
 				api.entity.set_direction(_paired_entity, api.entity.direction(_entity))
+			elseif _pair_data.class == pairclass.get("access-shaft") then
+				--Prevent people from opening or driving the access-shaft (since it's really a vehicle)
+				_entity.operable = false
+				--Add some fuel into the access-shaft vehicle to prevent the "no-fuel" icon from flashing
+				_entity.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 100})
+				
+				_paired_entity.operable = false
+				_paired_entity.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 100})
 			end
 		else
 			if _player_index and api.game.player(_player_index) then

--- a/src/script/proto.lua
+++ b/src/script/proto.lua
@@ -294,7 +294,7 @@ _prototypes.entity = {
 	},
 	access_shaft = {
 		common = {
-			type = "simple-entity", 
+			type = "car", 
 			flags = {},
 			collision_mask = {"object-layer", "player-layer"},
 			order = _prototypes.item.access_shaft.common.order,
@@ -305,19 +305,85 @@ _prototypes.entity = {
 			minable = {hardness = 1, mining_time = 8},
 			render_layer = "object",
 			map_color = util.RGB(127, 88, 43, 50),
+			acceleration_per_energy = 1,
+			breaking_speed = 0,
+			energy_per_hit_point = 1,
+			effectivity = 0.01,
+			burner = {
+				effectivity = 0.01,
+				fuel_inventory_size = 1
+			},
+			braking_power = "1W",
+			consumption = "0W",
+			friction = 0,
+			rotation_speed = 0,
+			weight = 100,
+			inventory_size = 0,
 			override = true
 		},
 		underground_entrance = {name = _prototypes.item.access_shaft.underground_entrance.name, icon = _prototypes.item.access_shaft.underground_entrance.icon,
-			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.underground_entrance.name .. ".png", "medium", 96, 96)
+			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.underground_entrance.name .. ".png", "medium", 96, 96),
+			animation = {
+				layers = {
+					{
+						filename = _gfxpath.entity .. _prototypes.item.access_shaft.underground_entrance.name .. ".png",
+						width = 96,
+						height = 96,
+						frame_count = 1,
+						direction_count = 1,
+						animation_speed = 0,
+						max_advance = 0
+					}
+				}
+			}
 		},
 		underground_exit = {name = _prototypes.item.access_shaft.underground_exit.name, icon = _prototypes.item.access_shaft.underground_exit.icon,
-			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.underground_exit.name .. ".png", "medium", 96, 96)
+			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.underground_exit.name .. ".png", "medium", 96, 96),
+			animation = {
+				layers = {
+					{
+						filename = _gfxpath.entity .. _prototypes.item.access_shaft.underground_exit.name .. ".png",
+						width = 96,
+						height = 96,
+						frame_count = 1,
+						direction_count = 1,
+						animation_speed = 0,
+						max_advance = 0
+					}
+				}
+			}
 		},
 		sky_entrance = {name = _prototypes.item.access_shaft.sky_entrance.name, icon = _prototypes.item.access_shaft.sky_entrance.icon,
-			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.sky_entrance.name .. ".png", "medium", 96, 96)
+			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.sky_entrance.name .. ".png", "medium", 96, 96),
+			animation = {
+				layers = {
+					{
+						filename = _gfxpath.entity .. _prototypes.item.access_shaft.sky_entrance.name .. ".png",
+						width = 96,
+						height = 96,
+						frame_count = 1,
+						direction_count = 1,
+						animation_speed = 0,
+						max_advance = 0
+					}
+				}
+			}
 		},
 		sky_exit = {name = _prototypes.item.access_shaft.sky_exit.name, icon = _prototypes.item.access_shaft.sky_exit.icon,
-			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.sky_exit.name .. ".png", "medium", 96, 96)
+			pictures = struct.Picture(_gfxpath.entity .. _prototypes.item.access_shaft.sky_exit.name .. ".png", "medium", 96, 96),
+			animation = {
+				layers = {
+					{
+						filename = _gfxpath.entity .. _prototypes.item.access_shaft.sky_exit.name .. ".png",
+						width = 96,
+						height = 96,
+						frame_count = 1,
+						direction_count = 1,
+						animation_speed = 0,
+						max_advance = 0
+					}
+				}
+			}
 		}
 	},
 	energy_transport = {


### PR DESCRIPTION
Turned access shafts into vehicles and made the script listen for the
on_player_driving_changed_state instead of checking if a player is near
every tick. Much less lag now.
